### PR TITLE
Fix ALSA sampling rate selection on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,7 @@ dependencies = [
  "flip-cell",
  "futures",
  "itertools",
+ "num-traits",
  "realfft",
  "rustfft",
  "shaderc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ itertools = "0.9.0"
 spin_sleep = { path = "3rdparty/spin_sleep-1.0.0" }
 clap = { version = "2.33.3", default-features = false }
 flip-cell = { path = "flip-cell" }
+num-traits = "0.2.14"
 
 [dependencies.winit]
 version = "0.24.0"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ If you are not using VSCode, you can launch the tests using the following:
 
 If you type `cargo run [...] --`, all arguments after the double-hyphen are passed to `spectro2` instead of `cargo run`.
 
-Example usage: `cargo run -- --loopback --volume 100`
+On Windows, an example command-line is: `cargo run -- --loopback --volume 100`
+
+On Linux with PulseAudio, you need to specify the sampling rate (and channel count) manually: `cargo run -- --sample-rate 48000 --channels 2` . Additionally, `--loopback` does not work (because spectro2 talks to PulseAudio through the ALSA API), so you need to open pavucontrol to enable loopback capture ([instructions here](https://wiki.ubuntu.com/record_system_sound#Audio_Loopback_Recording_With_PulseAudio)).
 
 **SEIZURE WARNING:** Rapidly changing audio can cause flashing lights, especially once colored stereo is added.
 


### PR DESCRIPTION
On Linux, cpal only supports ALSA, not PulseAudio (discussion at https://github.com/RustAudio/cpal/issues/259). PulseAudio exposes an ALSA plugin (`pulse`), which cpal uses on PulseAudio systems. This ALSA interface/plugin self-reports as accepting any sampling rate from 1 to 384000 Hz, and any channel count from 1 to 32. And our previous cpal code picks 384000 Hz and 1 channel, which is not the native sampling rate.

This PR adds CLI options for the user to override the sampling rate and channel count. Unfortunately there is no way (that I know of) to detect PulseAudio's native settings from ALSA. My research is in a [Google doc](https://docs.google.com/document/d/10EL1qd6ZPkn6ySAPlXY7oea80nWwPV4X4csI4m4ujuY/edit?usp=sharing).

- [ ] TODO: Add warning when more than 8 ranges are present (in Pulse, each has a different channel count)...
- [ ] Actually, require sampling rate whenever using ALSA and sampling rate range has more than 1 element.
- [ ] And require channel count whenever using ALSA.
  - Actually we don't support multiple channels yet. Maybe hard-code channel count to (2, 1, maximum supported) in descending preference. IDK if 1 channel alsa input downmixes or only sends left ear.
- [ ] Alternatively, warn when device is named `pulse`.