### PR TITLE
Make user pick sampling rate and channel count manually on bad ALSA setups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "inplace_it"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1846,7 @@ dependencies = [
  "dsp",
  "flip-cell",
  "futures",
+ "indoc",
  "itertools",
  "num-complex",
  "num-traits",
@@ -2183,6 +2193,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "unreachable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "2.33.3", default-features = false }
 flip-cell = { path = "flip-cell" }
 num-traits = "0.2.14"
 num-complex = "0.3.1"
+indoc = "1.0.3"
 
 [dependencies.winit]
 version = "0.24.0"

--- a/README.md
+++ b/README.md
@@ -38,14 +38,29 @@ USAGE:
     spectro2.exe [FLAGS] [OPTIONS]
 
 OPTIONS:
-    -l, --loopback
-            If passed, will listen to output device (speaker) instead of input (microphone)
+    -D, --show-devices
+            If passed, prints a list of audio devices, and stream modes for the chosen device
 
     -d, --device-index <device-index>
             If passed, will override which device is selected.
 
             This overrides --loopback for picking devices. However, you still need to pass --loopback if you pass an
             output device (speaker) to --device-index.
+    -s, --sample-rate <sample-rate>
+            Override the default sampling rate of the audio device.
+
+            If not passed, on Linux PulseAudio setups, spectro2 opens the input device at 384000 Hz and not the actual
+            PulseAudio sampling rate.
+    -c, --channels <channels>
+            Override the default channel count of the audio device.
+
+            If not passed, on Linux PulseAudio setups, spectro2 opens the input device with 1 channel and not the actual
+            PulseAudio channel count.
+    -l, --loopback
+            If passed, will listen to output device (speaker) instead of input (microphone).
+
+            Primarily intended for Windows WASAPI. Does not work on Linux PulseAudio; instead use pavucontrol to switch
+            the audio input to speaker loopback.
     -v, --volume <volume>
             How much to amplify the incoming signal before sending it to the spectrum viewer [default: 20]
 


### PR DESCRIPTION
- Add error if ALSA-supplied sampling rate and channel count are wrong
- Hide devices/configs by default to reduce text output, unless user passes `--show-devices` flag
- Only accept stream configs with i16 sample format, to avoid potential errors where f32 stream configs appear before i16

Fixes #11.