### PR TITLE
Fix most `cargo clippy` warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use winit::{
 const MIN_FFT_SIZE: usize = 4;
 const MAX_FFT_SIZE: usize = 16384;
 
-const APP_NAME: &'static str = env!("CARGO_PKG_NAME");
+const APP_NAME: &str = env!("CARGO_PKG_NAME");
 
 use structopt::StructOpt;
 
@@ -181,7 +181,7 @@ fn main() -> Result<()> {
     let mut opt = Opt::from_args();
     opt.parse_validate()?;
 
-    println!("");
+    println!();
 
     let host = cpal::default_host();
 
@@ -204,7 +204,7 @@ fn main() -> Result<()> {
             println!("    Input: {:?}", dev.default_input_config());
             println!("    Output: {:?}", dev.default_output_config());
         }
-        println!("");
+        println!();
     }
 
     // TODO add checkbox for toggling between input and loopback capture
@@ -252,7 +252,7 @@ fn main() -> Result<()> {
         for cfg in &supported_config_ranges {
             println!("- {:?}", cfg)
         }
-        println!("");
+        println!();
     };
 
     if should_warn {
@@ -309,13 +309,10 @@ fn main() -> Result<()> {
                 .context("no supported config?!")?;
 
             if let Some(channels) = opt.channels {
-                let first_valid_range = supported_config_ranges
-                    .iter()
-                    .filter(|range| {
-                        range.channels() as u32 == channels
-                            && range.sample_format() == cpal::SampleFormat::I16
-                    })
-                    .next();
+                let first_valid_range = supported_config_ranges.iter().find(|range| {
+                    range.channels() as u32 == channels
+                        && range.sample_format() == cpal::SampleFormat::I16
+                });
                 match first_valid_range {
                     Some(range) => range,
                     None => {


### PR DESCRIPTION
The `WindowEvent::KeyboardInput { input, .. } => match input` block still has a clippy warning. I don't want to rewrite this part of the code, since it was copied from learn-wgpu, and is written in a dense functional style making it difficult to understand.

https://github.com/nyanpasu64/spectro2/blob/d5186b885f41625fc31449af67b1d7fe93f6d0ed/src/main.rs#L485-L492

Note that `cargo clippy` will fail to report warnings in some cases. Specifically, both `cargo check` or `cargo clippy` will cache a set of warnings (larger in the case of `cargo clippy`) which will appear in all future runs of either command, until the code is modified and either command is run again. Bug report: https://github.com/rust-lang/rust-clippy/issues/1495