### PR TITLE
Unbind Esc from exiting the program

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -479,14 +479,6 @@ fn main() -> Result<()> {
             if !state.input(event) {
                 match event {
                     WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
-                    WindowEvent::KeyboardInput { input, .. } => match input {
-                        KeyboardInput {
-                            state: ElementState::Pressed,
-                            virtual_keycode: Some(VirtualKeyCode::Escape),
-                            ..
-                        } => *control_flow = ControlFlow::Exit,
-                        _ => {}
-                    },
                     WindowEvent::Resized(physical_size) => {
                         state.resize(*physical_size);
                     }


### PR DESCRIPTION
If you take a rectangle screenshot with KDE X11 Spectacle, and press Esc to close the screenshot region selector, it also closes spectro2, which is an annoyance.

The easiest workaround is to unbind Esc from closing the program. Alt+F4 and the close button still work.

Fixes #25.