### PR TITLE
Change default window size to 1280x720

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -431,8 +431,8 @@ fn main() -> Result<()> {
     let window = {
         let window_builder = WindowBuilder::new()
             .with_inner_size(PhysicalSize {
-                width: 1024,
-                height: 768,
+                width: 1280,
+                height: 720,
             })
             .with_title(APP_NAME);
         #[cfg(target_os = "windows")]


### PR DESCRIPTION
Widescreen is a more popular video format, and the wider window shows high frequencies which were previously cut off.

Fixes #29.